### PR TITLE
Update pre_start.sh

### DIFF
--- a/scripts/pre_start.sh
+++ b/scripts/pre_start.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 export PYTHONUNBUFFERED=1
+export TMPDIR=/workspace/tmp
 
 echo "Container is running"
 
@@ -15,7 +16,7 @@ rsync -au /facefusion/ /workspace/facefusion/
 echo "Fixing venv..."
 /fix_venv.sh /venv /workspace/venv
 
-mkdir -p /workspace/logs
+mkdir -p /workspace/logs /workspace/tmp
 
 if [[ ${DISABLE_AUTOLAUNCH} ]]
 then


### PR DESCRIPTION
When working with videos the temp frames if saved as .png(default) the container disk will run out of space very quickly. 1minute 1080p video = ~4gb